### PR TITLE
Remove duplicate observer registration in initial usage example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -106,10 +106,6 @@ Usage Example {#example}
             // ...
         }
     });
-    // Register observer for previous and future long task notifications.
-    observer.observe({type: "long-animation-frame", buffered: true});
-    // Long script execution after this will result in queueing
-    // and receiving "long-animation-frame" entries in the observer.
 
     // Register observer for previous and future long animation frame notifications.
     // After this, long periods where the main thread is busy will result in queueing


### PR DESCRIPTION
closes https://github.com/w3c/long-animation-frames/issues/24