### PR TITLE
Add styleDuration, layoutDuration, forcedStyleDuration, and forcedLayoutDuration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -70,6 +70,7 @@ urlPrefix: https://tc39.es/ecma262/multipage/managing-memory.html
 
 <pre class=link-defaults>
 spec:html; type:dfn; for:/; text:browsing context
+spec:hr-time-3; type:dfn; text:duration
 </pre>
 
 Introduction {#intro}
@@ -159,6 +160,7 @@ Long Animation Frame timing involves the following new interfaces:
         readonly attribute DOMHighResTimeStamp renderStart;
         readonly attribute DOMHighResTimeStamp styleAndLayoutStart;
         readonly attribute DOMHighResTimeStamp styleDuration;
+        readonly attribute DOMHighResTimeStamp layoutDuration;
         readonly attribute DOMHighResTimeStamp blockingDuration;
         readonly attribute DOMHighResTimeStamp firstUIEventTimestamp;
         [SameObject] readonly attribute FrozenArray&lt;PerformanceScriptTiming&gt; scripts;
@@ -183,6 +185,8 @@ The {{PerformanceLongAnimationFrameTiming/renderStart}} attribute's getter step 
 The {{PerformanceLongAnimationFrameTiming/styleAndLayoutStart}} attribute's getter step is to return the [=relative high resolution time=] given [=this=]'s [=PerformanceLongAnimationFrameTiming/timing info=]'s [=frame timing info/style and layout start time=] and [=this=]'s [=relevant global object=].
 
 The {{PerformanceLongAnimationFrameTiming/styleDuration}} attribute's getter step is to return [=this=]'s [=PerformanceLongAnimationFrameTiming/timing info=]'s [=frame timing info/style duration=].
+
+The {{PerformanceLongAnimationFrameTiming/layoutDuration}} attribute's getter step is to return [=this=]'s [=PerformanceLongAnimationFrameTiming/timing info=]'s [=frame timing info/layout duration=].
 
 The {{PerformanceLongAnimationFrameTiming/firstUIEventTimestamp}} attribute's getter step is to return the [=relative high resolution time=] given [=this=]'s [=PerformanceLongAnimationFrameTiming/timing info=]'s [=frame timing info/first ui event timestamp=] and [=this=]'s [=relevant global object=].
 
@@ -263,6 +267,7 @@ The {{PerformanceLongAnimationFrameTiming/scripts}} attribute's getter steps are
         readonly attribute DOMHighResTimeStamp pauseDuration;
         readonly attribute DOMHighResTimeStamp forcedStyleAndLayoutDuration;
         readonly attribute DOMHighResTimeStamp forcedStyleDuration;
+        readonly attribute DOMHighResTimeStamp forcedLayoutDuration;
         readonly attribute Window? window;
         readonly attribute ScriptWindowAttribution windowAttribution;
         [Default] object toJSON();
@@ -324,6 +329,10 @@ The {{PerformanceScriptTiming/forcedStyleDuration}} attribute's getter step is t
 
     Issue: Find a way to make this interoperable/normative.
 
+The {{PerformanceScriptTiming/forcedLayoutDuration}} attribute's getter step is to return an [=implementation-defined=] value that represents time spent performing layout synchronously (without style recalculation), e.g. by calling {{Element/getBoundingClientRect()}} after the layout is already invalidated.
+
+    Issue: Find a way to make this interoperable/normative.
+
 The {{PerformanceScriptTiming/pauseDuration}} attribute's getter step is to return [=this=]'s [=PerformanceScriptTiming/timing info=]'s [=script timing info/pause duration=].
 
 The {{PerformanceScriptTiming/sourceURL}} attribute's getter step is to return [=this=]'s [=PerformanceScriptTiming/timing info=]'s [=script timing info/source url=].
@@ -359,6 +368,9 @@ It has the following [=struct/items=]:
         and should be [=coarsen time|coarsened=] when exposed via an API.
 
     : <dfn>style duration</dfn>
+    :: A {{DOMHighResTimeStamp}} representing a number of milliseconds, initially 0.
+
+    : <dfn>layout duration</dfn>
     :: A {{DOMHighResTimeStamp}} representing a number of milliseconds, initially 0.
 
     : <dfn>task durations</dfn>


### PR DESCRIPTION
This PR adds the `styleDuration` and `layoutDuration` attributes to PerformanceLongAnimationFrameTiming and the `forcedStyleDuration` and `forcedLayoutDuration` attributes to PerformanceScriptTiming.

This would enable developers to distinguish between the style calculation times and their layout times, which typically have very distinct reasons, and therefore different solutions.

It also includes a couple of tiny unrelated bikeshed fixes.

Currently developers can collect their overall style+layout costs using something like the following:
```
const totalStyleCost = async () => {
  return new Promise(resolve => {
    let total = 0;
    (new PerformanceObserver(entryList => {
      const entries = entryList.getEntries();
      for (const entry of entries) {
          if (entry.paintTime) {
              total += entry.paintTime - entry.styleAndLayoutStart;
          } else {
              total += entry.startTime + entry.duration - entry.styleAndLayoutStart;
          }
          for (const script of entry.scripts) {
              total += script.forcedStyleAndLayoutDuration;
          }
      }
      resolve(total);
    })).observe({type: "long-animation-frame", buffered: true});
  });
}
```

This feature will enable developers to collect their overall style calculation time and layout time separately, using:
```
const totalStyleAndLayoutCost = async () => {                                              
    return new Promise(resolve => {                                                                                                                                                                                 
      let totalStyle = 0;                                                                                                                                                                                           
      let totalLayout = 0;                                                                                                                                                                                          
      (new PerformanceObserver(entryList => {                                                                                                                                                                       
        const entries = entryList.getEntries();                                                                                                                                                                     
        for (const entry of entries) {                                                                                                                                                                              
            totalStyle += entry.styleDuration;                                                                                                                                                                      
            totalLayout += entry.layoutDuration;                                                                                                                                                                    
                                                                                                                                                                                                                    
            for (const script of entry.scripts) {                                                                                                                                                                   
                totalStyle += script.forcedStyleDuration;                                                                                                                                                           
                totalLayout += script.forcedLayoutDuration;                                                                                                                                                         
            }                                                                                                                                                                                                       
        }                                                                                                                                                                                                           
        resolve({totalStyle, totalLayout});                                                                                                                                                                         
      })).observe({type: "long-animation-frame", buffered: true});                                                                                                                                                  
    });                                                                                                                                                                                                             
  }
```

That would enable them to evaluate e.g. if they need to opt in for cheaper/simpler CSS selectors and reduce their overall number of delivered rules (high style costs), or simplify their DOM structure and      
reduce layout-triggering property usage (high layout costs).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/long-animation-frames/pull/30.html" title="Last updated on Mar 6, 2026, 3:57 PM UTC (d5b0604)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/long-animation-frames/30/ae40032...d5b0604.html" title="Last updated on Mar 6, 2026, 3:57 PM UTC (d5b0604)">Diff</a>