### PR TITLE
Treat "fire an event" and script execution blocks as "tasks" if outside document-associated task

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -622,7 +622,7 @@ Report Long Animation Frames {#loaf-processing-model}
         [=list/append=] |scriptTimingInfo| to |frameTimingInfo|'s [=frame timing info/scripts=].
     1. If |frameTimingInfo| is [=frame timing info/script initiated=], then [=record task end time=] given |endTime| and |document|.
 
-        Note: For event listeners, the task ends at the end of the [=fire an event=] algorithm rather than at the end of a single listener's execution.
+        Note: For event listeners, the task lifetime is managed by the [=fire an event=] algorithm, which may invoke multiple listeners to the same event, rather than at the end of a single listener's execution.
 </div>
 
 <div algorithm="Applying source location">

--- a/index.bs
+++ b/index.bs
@@ -566,7 +566,7 @@ Report Long Animation Frames {#loaf-processing-model}
         1. If |settings| is not a {{Window}}, then return.
         1. Let |document| be |settings|'s {{Window/document}}.
         1. Let |frameTimingInfo| be |document|'s [=relevant frame timing info=].
-        1. [=Assert=]: |frameTimingInfo| is non-nulll.
+        1. [=Assert=]: |frameTimingInfo| is non-null.
         1. If |frameTimingInfo|'s [=frame timing info/pending script=] is not null, then return.
         1. Set |frameTimingInfo|'s [=frame timing info/pending script=]'s [=script timing info/execution start time=] to the [=unsafe shared current time=].
 </div>

--- a/index.bs
+++ b/index.bs
@@ -365,8 +365,8 @@ It has the following [=struct/items=]:
     : <dfn>pending script</dfn>
     :: Null or a [=script timing info=], initially null.
 
-    : <dfn>current task invoker type</dfn>
-    :: Null or a {{ScriptInvokerType}}, initially nulll.
+    : <dfn>script initiated</dfn>
+    :: A boolean, initially false.
 </dl>
 
 <dfn export>script timing info</dfn> is a [=struct=]. It has the following [=struct/items=]:
@@ -418,18 +418,6 @@ Report Long Animation Frames {#loaf-processing-model}
     1. Return |document|.
 
     The <dfn>relevant frame timing info</dfn> for a {{Document}} |document| is its [=nearest same-origin root=]'s [=current frame timing info=].
-
-    To <dfn>get relevant frame timing info for script</dfn> given a {{Document}} |document| and a {{ScriptInvokerType}} |type|:
-
-        Note: this allows monitoring long animation frame in scenarios where there is no document-associated task.
-        The "task" in this case, as far as the long animation frame processing model is concerned, is either a script block or when [=fire an event|firing an event=].
-
-        1. Let |document|'s [=relevant frame timing info=] is non-null, then return |document|'s [=relevant frame timing info=].
-        1. [=Record task start time=] given the [=unsafe shared current time=] and |document|.
-        1. Let |timingInfo| be |document|'s [=relevant frame timing info=].
-        1. [=Assert=]: |timingInfo| is non-null.
-        1. Set |timingInfo|'s [=current task invoker type=] to |type|.
-        1. Return |timingInfo|.
 </div>
 
 <div algorithm="Record task start time">
@@ -569,9 +557,9 @@ Report Long Animation Frames {#loaf-processing-model}
         1. If |script|'s [=classic script/muted errors=] is true, then return.
         1. If |settings| is not a {{Window}}, then return.
         1. Let |document| be |settings|'s {{Window/document}}.
-        1. Let |frameTimingInfo| be the result of calling [=get relevant frame timing info for script=] given |document| and `script`.
+        1. Let |frameTimingInfo| be |document|'s [=relevant frame timing info=].
+        1. [=Assert=]: |frameTimingInfo| is non-nulll.
         1. If |frameTimingInfo|'s [=frame timing info/pending script=] is not null, then return.
-        1. Assert: |frameTimingInfo|'s [=frame timing info/pending script=]'s [=script timing info/invoker type=] is "`classic-script`".
         1. Set |frameTimingInfo|'s [=frame timing info/pending script=]'s [=script timing info/execution start time=] to the [=unsafe shared current time=].
 </div>
 
@@ -591,7 +579,12 @@ Report Long Animation Frames {#loaf-processing-model}
         1. If |settings| is not a {{Window}}, then return.
         1. Let |document| be |settings|'s {{Window/document}}.
         1. If |document| is not [=fully active=] or	{{Document/hidden}}, then return.
-        1. Let |frameTimingInfo| be the result of calling [=get relevant frame timing info for script=] given |document| and |invokerType|.
+        1. Let |frameTimingInfo| be |document|'s [=relevant frame timing info=].
+        1. If |frameTimingInfo| is null, then
+            1. [=Record task start time=] given the [=unsafe shared current time=] and |document|.
+            1. Set |frameTimingInfo| to |document|'s [=relevant frame timing info=].
+            1. Set |frameTimingInfo|'s [=script initiated=] to true.
+        1. [=Assert=]: |frameTimingInfo| is non-null.
         1. If |frameTimingInfo|'s [=frame timing info/pending script=] is not null, then return.
         1. Let |scriptTimingInfo| be a new [=script timing info=]
             whose [=script timing info/start time=] is the [=unsafe shared current time=],
@@ -621,7 +614,7 @@ Report Long Animation Frames {#loaf-processing-model}
         1. set |scriptTimingInfo|'s [=script timing info/source function name=] to the empty string.
     1. If the [=duration=] between |scriptTimingInfo|'s [=script timing info/start time=] and |scriptTimingInfo|'s [=script timing info/end time=] is greater than 5 milliseconds, then
         [=list/append=] |scriptTimingInfo| to |frameTimingInfo|'s [=frame timing info/scripts=].
-    1. If |frameTimingInfo|'s [=current task invoker type=] is not null or "`event-listener`", then [=record task end time=] given |endTime| and |document|.
+    1. If |frameTimingInfo| is [=frame timing info/script initiated=], then [=record task end time=] given |endTime| and |document|.
 
         Note: For event listeners, the task ends at the end of the [=fire an event=] algorithm rather than at the end of a single listener's execution.
 </div>
@@ -652,10 +645,13 @@ Additions to existing standards {#other-standards}
 Monkey-patches to the DOM API {#dom-api-monkey-patches}
 ----------------------------------------------------------
 <div algorithm="Monkey patches to event firing">
-    At the end of the [=fire an event=] algorithm:
-        1. If the event's [=relevant realm=]'s [=realm/settings object=] is a {{Document}} |document|:
-            1. If |document|'s [=relevant frame timing info=] is non-null and its [=frame timing info/current task invoker type=] is "`event-listener`":
-                1. [=Record task end time=] given the [=unsafe shared current time=] and |document|.
+Patch the [=fire an event=] algorithm as follows given |target|:
+    1. Let |eventInitiatedTask| be false;
+    1. If |target|'s [=relevant settings object=] is a {{Document}} whose [=relevant frame timing info=] is null, then:
+        1. Let |document| be |target|'s [=relevant settings object=].
+        1. Set |eventInitiatedTask| to true.
+        1. [=Record task start time=] given the [=unsafe shared current time=] and |document|.
+    1. At the end of the algorithm, if |eventInitiatedTask| is true, then [=record task end time=] given the [=unsafe shared current time=] and |document|.
 </div>
 
 Monkey-patches to the WebIDL standard {#webidl-monkey-patches}

--- a/index.bs
+++ b/index.bs
@@ -420,6 +420,15 @@ Report Long Animation Frames {#loaf-processing-model}
     The <dfn>relevant frame timing info</dfn> for a {{Document}} |document| is its [=nearest same-origin root=]'s [=current frame timing info=].
 </div>
 
+<div algorithm="Record if needed">
+    To <dfn export>start recording task time if needed</dfn> given an [=environment settings object=] |settingsObject|:
+
+    1. If |settingsObject| is not a {{Document}} or its [=relevant frame timing info=] is non-null, then return false.
+    1. [=Record task start time=] given the [=unsafe shared current time=] and |settingsObject|.
+    1. Return true.
+</div>
+
+
 <div algorithm="Record task start time">
     To <dfn export>record task start time</dfn> given a {{DOMHighResTimeStamp}} |unsafeTaskStartTime|, and a null or {{Document}} |document|:
 
@@ -579,12 +588,10 @@ Report Long Animation Frames {#loaf-processing-model}
         1. If |settings| is not a {{Window}}, then return.
         1. Let |document| be |settings|'s {{Window/document}}.
         1. If |document| is not [=fully active=] or	{{Document/hidden}}, then return.
+        1. Let |didStartRecording| be the result of calling [=start recording task time if needed=] given |document|.
         1. Let |frameTimingInfo| be |document|'s [=relevant frame timing info=].
-        1. If |frameTimingInfo| is null, then
-            1. [=Record task start time=] given the [=unsafe shared current time=] and |document|.
-            1. Set |frameTimingInfo| to |document|'s [=relevant frame timing info=].
-            1. Set |frameTimingInfo|'s [=script initiated=] to true.
         1. [=Assert=]: |frameTimingInfo| is non-null.
+        1. Set |frameTimingInfo|'s [=script initiated=] to |didStartRecording|.
         1. If |frameTimingInfo|'s [=frame timing info/pending script=] is not null, then return.
         1. Let |scriptTimingInfo| be a new [=script timing info=]
             whose [=script timing info/start time=] is the [=unsafe shared current time=],
@@ -646,12 +653,9 @@ Monkey-patches to the DOM API {#dom-api-monkey-patches}
 ----------------------------------------------------------
 <div algorithm="Monkey patches to event firing">
 Patch the [=fire an event=] algorithm as follows given |target|:
-    1. Let |eventInitiatedTask| be false;
-    1. If |target|'s [=relevant settings object=] is a {{Document}} whose [=relevant frame timing info=] is null, then:
-        1. Let |document| be |target|'s [=relevant settings object=].
-        1. Set |eventInitiatedTask| to true.
-        1. [=Record task start time=] given the [=unsafe shared current time=] and |document|.
-    1. At the end of the algorithm, if |eventInitiatedTask| is true, then [=record task end time=] given the [=unsafe shared current time=] and |document|.
+    1. Let |eventInitiatedTask| be the result of calling [=start recording task time if needed=] given |target|'s [=relevant settings object=];
+    1. At the end of the algorithm:
+        If |eventInitiatedTask| is true, then [=record task end time=] given the [=unsafe shared current time=] and |target|'s [=relevant settings object=].
 </div>
 
 Monkey-patches to the WebIDL standard {#webidl-monkey-patches}

--- a/index.bs
+++ b/index.bs
@@ -434,12 +434,7 @@ Report Long Animation Frames {#loaf-processing-model}
 
 
 <div algorithm="Record task start time">
-    To <dfn export>record task start time</dfn> given a {{DOMHighResTimeStamp}} |unsafeTaskStartTime|, and a null or {{Document}} |document|:
-
-    1. If |document| is null, return.
-
-        Note: according to the HTML standard, a task always has an associated [=task/document=]. However, this often requires getting it via the [=implied document=].
-        This spec is more rigorous as it doesn't rely on the concept of the [=implied document=] and instead defines what happens when scripts or events run in a document-less task.
+    To <dfn export>record task start time</dfn> given a {{DOMHighResTimeStamp}} |unsafeTaskStartTime|, and a {{Document}} |document|:
 
     1. Let |root| be |document|'s [=nearest same-origin root=].
 

--- a/index.bs
+++ b/index.bs
@@ -60,6 +60,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML;
     type: dfn; url: #running-script; text: running script;
     type: dfn; url: #muted-errors; for: classic script; text: muted errors;
     type: dfn; url: #cors-cross-origin; text: CORS cross-origin;
+    type: dfn; url: #implied-document; text: implied document;
+    type: dfn: url: #concept-task-document; text: document; for: task;
 urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT;
     type: dfn; url: #sec-code-realms; text: JavaScript Realms;
 urlPrefix: https://dom.spec.whatwg.org/; spec: DOM;
@@ -362,6 +364,9 @@ It has the following [=struct/items=]:
 
     : <dfn>pending script</dfn>
     :: Null or a [=script timing info=], initially null.
+
+    : <dfn>current task invoker type</dfn>
+    :: Null or a {{ScriptInvokerType}}, initially nulll.
 </dl>
 
 <dfn export>script timing info</dfn> is a [=struct=]. It has the following [=struct/items=]:
@@ -413,10 +418,27 @@ Report Long Animation Frames {#loaf-processing-model}
     1. Return |document|.
 
     The <dfn>relevant frame timing info</dfn> for a {{Document}} |document| is its [=nearest same-origin root=]'s [=current frame timing info=].
+
+    To <dfn>get relevant frame timing info for script</dfn> given a {{Document}} |document| and a {{ScriptInvokerType}} |type|:
+
+        Note: this allows monitoring long animation frame in scenarios where there is no document-associated task.
+        The "task" in this case, as far as the long animation frame processing model is concerned, is either a script block or when [=fire an event|firing an event=].
+
+        1. Let |document|'s [=relevant frame timing info=] is non-null, then return |document|'s [=relevant frame timing info=].
+        1. [=Record task start time=] given the [=unsafe shared current time=] and |document|.
+        1. Let |timingInfo| be |document|'s [=relevant frame timing info=].
+        1. [=Assert=]: |timingInfo| is non-null.
+        1. Set |timingInfo|'s [=current task invoker type=] to |type|.
+        1. Return |timingInfo|.
 </div>
 
 <div algorithm="Record task start time">
-    To <dfn export>record task start time</dfn> given a {{DOMHighResTimeStamp}} |unsafeTaskStartTime|, and a {{Document}} |document|:
+    To <dfn export>record task start time</dfn> given a {{DOMHighResTimeStamp}} |unsafeTaskStartTime|, and a null or {{Document}} |document|:
+
+    1. If |document| is null, return.
+
+        Note: according to the HTML standard, a task always has an associated [=task/document=]. However, this often requires getting it via the [=implied document=].
+        This spec is more rigorous as it doesn't rely on the concept of the [=implied document=] and instead defines what happens when scripts or events run in a document-less task.
 
     1. Let |root| be |document|'s [=nearest same-origin root=].
 
@@ -547,8 +569,8 @@ Report Long Animation Frames {#loaf-processing-model}
         1. If |script|'s [=classic script/muted errors=] is true, then return.
         1. If |settings| is not a {{Window}}, then return.
         1. Let |document| be |settings|'s {{Window/document}}.
-        1. Let |frameTimingInfo| be |document|'s [=relevant frame timing info=].
-        1. If |frameTimingInfo| is null or if |frameTimingInfo|'s [=frame timing info/pending script=] is not null, then return.
+        1. Let |frameTimingInfo| be the result of calling [=get relevant frame timing info for script=] given |document| and `script`.
+        1. If |frameTimingInfo|'s [=frame timing info/pending script=] is not null, then return.
         1. Assert: |frameTimingInfo|'s [=frame timing info/pending script=]'s [=script timing info/invoker type=] is "`classic-script`".
         1. Set |frameTimingInfo|'s [=frame timing info/pending script=]'s [=script timing info/execution start time=] to the [=unsafe shared current time=].
 </div>
@@ -569,8 +591,7 @@ Report Long Animation Frames {#loaf-processing-model}
         1. If |settings| is not a {{Window}}, then return.
         1. Let |document| be |settings|'s {{Window/document}}.
         1. If |document| is not [=fully active=] or	{{Document/hidden}}, then return.
-        1. Let |frameTimingInfo| be |document|'s [=relevant frame timing info=].
-        1. If |frameTimingInfo| is null, then return.
+        1. Let |frameTimingInfo| be the result of calling [=get relevant frame timing info for script=] given |document| and |invokerType|.
         1. If |frameTimingInfo|'s [=frame timing info/pending script=] is not null, then return.
         1. Let |scriptTimingInfo| be a new [=script timing info=]
             whose [=script timing info/start time=] is the [=unsafe shared current time=],
@@ -588,16 +609,21 @@ Report Long Animation Frames {#loaf-processing-model}
     1. Let |document| be |settings|'s {{Window/document}}.
     1. If |document| is not [=fully active=] or	{{Document/hidden}}, then return.
     1. Let |frameTimingInfo| be |document|'s [=relevant frame timing info=].
+    1. [=Assert=]: |frameTimingInfo| is not null.
     1. Let |scriptTimingInfo| be |frameTimingInfo|'s [=frame timing info/pending script=].
+    1. Let |endTime| be the [=unsafe shared current time=].
     1. Set |frameTimingInfo|'s [=frame timing info/pending script=] to null.
     1. If |scriptTimingInfo| is null, then return.
-    1. Set |scriptTimingInfo|'s [=script timing info/end time=] to the [=unsafe shared current time=].
+    1. Set |scriptTimingInfo|'s [=script timing info/end time=] to |endTime|.
     1. If |script| is a [=classic script=] whose [=classic script/muted errors=] is true, then:
         1. set |scriptTimingInfo|'s [=script timing info/source url=] to the empty string.
         1. set |scriptTimingInfo|'s [=script timing info/source character position=] to -1.
         1. set |scriptTimingInfo|'s [=script timing info/source function name=] to the empty string.
     1. If the [=duration=] between |scriptTimingInfo|'s [=script timing info/start time=] and |scriptTimingInfo|'s [=script timing info/end time=] is greater than 5 milliseconds, then
         [=list/append=] |scriptTimingInfo| to |frameTimingInfo|'s [=frame timing info/scripts=].
+    1. If |frameTimingInfo|'s [=current task invoker type=] is not null or "`event-listener`", then [=record task end time=] given |endTime| and |document|.
+
+        Note: For event listeners, the task ends at the end of the [=fire an event=] algorithm rather than at the end of a single listener's execution.
 </div>
 
 <div algorithm="Applying source location">
@@ -614,14 +640,23 @@ Report Long Animation Frames {#loaf-processing-model}
     1. If |settings| is not a {{Window}}, then return.
     1. Let |document| be |settings|'s {{Window/document}}.
     1. If |document| is not [=fully active=] or	{{Document/hidden}}, then return.
-    1. Let |frameTimingInfo| be |document|'s [=relevant frame timing info=].
-    1. If |frameTimingInfo| is null, then return.
+    1. Let |frameTimingInfo| be the [=relevant frame timing info=] given |document|.
+    1. Assert: |frameTimingInfo| is not null.
     1. If |frameTimingInfo|'s [=frame timing info/pending script=] is null, then return.
     1. Increment |frameTimingInfo|'s [=frame timing info/pending script=]'s [=script timing info/pause duration=] by the milliseconds value of |duration|.
 </div>
 
 Additions to existing standards {#other-standards}
 ==================================================
+
+Monkey-patches to the DOM API {#dom-api-monkey-patches}
+----------------------------------------------------------
+<div algorithm="Monkey patches to event firing">
+    At the end of the [=fire an event=] algorithm:
+        1. If the event's [=relevant realm=]'s [=realm/settings object=] is a {{Document}} |document|:
+            1. If |document|'s [=relevant frame timing info=] is non-null and its [=frame timing info/current task invoker type=] is "`event-listener`":
+                1. [=Record task end time=] given the [=unsafe shared current time=] and |document|.
+</div>
 
 Monkey-patches to the WebIDL standard {#webidl-monkey-patches}
 ----------------------------------------------------------

--- a/index.bs
+++ b/index.bs
@@ -423,6 +423,10 @@ Report Long Animation Frames {#loaf-processing-model}
 <div algorithm="Record if needed">
     To <dfn export>start recording task time if needed</dfn> given an [=environment settings object=] |settingsObject|:
 
+    Note: this is called from the [=fire an event=] algorithm and the [=create script entry point=] algorithm.
+    It starts recording frame timing info for the duration of the [=fire an event|event firing=] or [=create script entry point|script=], as if it was a task.
+    This accounts for script and event durations that are not associated with tasks, which would otherwise require an [=implied document=].
+
     1. If |settingsObject| is not a {{Document}} or its [=relevant frame timing info=] is non-null, then return false.
     1. [=Record task start time=] given the [=unsafe shared current time=] and |settingsObject|.
     1. Return true.
@@ -648,15 +652,6 @@ Report Long Animation Frames {#loaf-processing-model}
 
 Additions to existing standards {#other-standards}
 ==================================================
-
-Monkey-patches to the DOM API {#dom-api-monkey-patches}
-----------------------------------------------------------
-<div algorithm="Monkey patches to event firing">
-Patch the [=fire an event=] algorithm as follows given |target|:
-    1. Let |eventInitiatedTask| be the result of calling [=start recording task time if needed=] given |target|'s [=relevant settings object=];
-    1. At the end of the algorithm:
-        If |eventInitiatedTask| is true, then [=record task end time=] given the [=unsafe shared current time=] and |target|'s [=relevant settings object=].
-</div>
 
 Monkey-patches to the WebIDL standard {#webidl-monkey-patches}
 ----------------------------------------------------------


### PR DESCRIPTION
Some operations, like UI events, are not defined in terms of tasks. When those operations invoke a script or fire an event, treat the script or event firing timeframe as a "task" for the purposes of LoAF reporting.

Currently, those should have a document associated to them with the "implied document" concept, however that is not interoperable and deprecated.

Together with https://github.com/whatwg/dom/pull/1462
Closes #36


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/long-animation-frames/pull/37.html" title="Last updated on Apr 16, 2026, 12:39 PM UTC (19d2042)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/long-animation-frames/37/03ba589...19d2042.html" title="Last updated on Apr 16, 2026, 12:39 PM UTC (19d2042)">Diff</a>